### PR TITLE
hawtio v2 keycloak client config expects only "url", "realm", and "clientId"

### DIFF
--- a/pax-keycloak-hawtio/src/main/resources/org/ops4j/pax/keycloak/hawtio/keycloak-hawtio.json
+++ b/pax-keycloak-hawtio/src/main/resources/org/ops4j/pax/keycloak/hawtio/keycloak-hawtio.json
@@ -1,7 +1,5 @@
 {
-  "realm" : "demo",
-  "resource" : "hawtio-client",
-  "auth-server-url" : "http://localhost:8080/auth",
-  "ssl-required" : "external",
-  "public-client" : true
+  "url": "http://localhost:8080/auth",
+  "realm": "demo",
+  "clientId": "hawtio-client"
 }


### PR DESCRIPTION
It corresponds to the argument of the third `Keycloak()` constructor option:
http://www.keycloak.org/docs/latest/securing_apps/index.html#javascript-adapter-reference