### PR TITLE
Downgrade dependency Karaf version so that pax-keycloak-jaas can install on 4.1.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
 
-        <dependency.karaf.version>4.2.0.M1</dependency.karaf.version>
+        <dependency.karaf.version>4.1.5</dependency.karaf.version>
         <dependency.keycloak.version>3.4.1.Final</dependency.keycloak.version>
         <dependency.bouncycastle.version>1.56</dependency.bouncycastle.version>
         <dependency.jackson.version>2.7.0</dependency.jackson.version>


### PR DESCRIPTION
Otherwise I get this error when doing `feature:install pax-keycloak` on Karaf 4.1.x

> Unable to resolve root: missing requirement [root] osgi.identity; osgi.identity=pax-keycloak-jaas; type=karaf.feature; version="[3.4.1.Final,3.4.1.Final]"; filter:="(&(osgi.identity=pax-keycloak-jaas)(type=karaf.feature)(version>=3.4.1.Final)(version<=3.4.1.Final))" [caused by: Unable to resolve pax-keycloak-jaas/3.4.1.Final: missing requirement [pax-keycloak-jaas/3.4.1.Final] osgi.identity; osgi.identity=org.ops4j.pax.keycloak.pax-keycloak-jaas; type=osgi.bundle; version="[0.3.0.SNAPSHOT,0.3.0.SNAPSHOT]"; resolution:=mandatory [caused by: Unable to resolve org.ops4j.pax.keycloak.pax-keycloak-jaas/0.3.0.SNAPSHOT: missing requirement [org.ops4j.pax.keycloak.pax-keycloak-jaas/0.3.0.SNAPSHOT] osgi.wiring.package; filter:="(&(osgi.wiring.package=org.apache.karaf.jaas.config)(version>=4.2.0)(!(version>=5.0.0)))"]]