### PR TITLE
Change the default hawtio.roles to the standard set of Karaf roles

### DIFF
--- a/pax-keycloak-hawtio/src/main/java/org/ops4j/pax/keycloak/hawtio/Activator.java
+++ b/pax-keycloak-hawtio/src/main/java/org/ops4j/pax/keycloak/hawtio/Activator.java
@@ -47,7 +47,7 @@ public class Activator implements BundleActivator {
 
             boolean modified = false;
             modified |= setIfNot(props, "hawtio.keycloakEnabled", "true", null, "\n# Hawtio / Keycloak integration");
-            modified |= setIfNot(props, "hawtio.roles", "admin,user", null, null);
+            modified |= setIfNot(props, "hawtio.roles", "admin,manager,viewer", null, null);
             modified |= setIfNot(props, "hawtio.realm", "karaf", null, null);
             modified |= setIfNot(props, "hawtio.keycloakClientConfig", "file://" + etc + "/keycloak-hawtio.json", "file://${karaf.etc}/keycloak-hawtio.json", null);
             modified |= setIfNot(props, "hawtio.rolePrincipalClasses", "org.keycloak.adapters.jaas.RolePrincipal,org.apache.karaf.jaas.boot.principal.RolePrincipal", null, null);


### PR DESCRIPTION
The role `user` is useless because hawtio checks RBAC on Karaf and thus a user with `user` role cannot access anything with the default Karaf setup. It's more sensible to have the standard set of roles `admin,manager,viewer` here.